### PR TITLE
Fixing XXE in all DocumentBuilderFactory usages in balana

### DIFF
--- a/modules/balana-core/pom.xml
+++ b/modules/balana-core/pom.xml
@@ -65,6 +65,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>xerces.wso2</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/balana-core/pom.xml
+++ b/modules/balana-core/pom.xml
@@ -66,8 +66,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>xerces.wso2</groupId>
-            <artifactId>xercesImpl</artifactId>
+            <groupId>org.wso2.balana</groupId>
+            <artifactId>org.wso2.balana.utils</artifactId>
         </dependency>
     </dependencies>
 
@@ -109,6 +109,7 @@
                             javax.xml.transform.stream; version="${imp.pkg.version.javax.xml}",
                             javax.xml.xpath; version="${imp.pkg.version.javax.xml}",
                             org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                            org.wso2.balana.utils;version="${imp.pkg.version.balana}",
                             org.w3c.dom,
                             org.xml.sax
                         </Import-Package>

--- a/modules/balana-core/src/main/java/org/wso2/balana/Balana.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/Balana.java
@@ -32,6 +32,7 @@ import org.wso2.balana.finder.PolicyFinderModule;
 import org.wso2.balana.finder.impl.CurrentEnvModule;
 import org.wso2.balana.finder.impl.FileBasedPolicyFinderModule;
 import org.wso2.balana.finder.impl.SelectorModule;
+import org.wso2.balana.utils.Utils;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -96,11 +97,6 @@ public class Balana {
      * Logger instance
      */
     private static Log logger = LogFactory.getLog(Balana.class);
-
-    /**
-     * Defines XML Entity Expansion Limit
-     */
-    private static final int ENTITY_EXPANSION_LIMIT = 0;
 
     /**
      * This constructor creates the Balana engine instance. First, it loads all configuration
@@ -219,7 +215,7 @@ public class Balana {
         }
 
         // init builder
-        this.builder = getSecuredDocumentBuilder();
+        this.builder = Utils.getSecuredDocumentBuilder();
     }
 
     /**
@@ -332,28 +328,5 @@ public class Balana {
 
     public DocumentBuilderFactory getBuilder() {
         return builder;
-    }
-
-    private DocumentBuilderFactory getSecuredDocumentBuilder() {
-
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        dbf.setXIncludeAware(false);
-        dbf.setExpandEntityReferences(false);
-        try {
-            dbf.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
-            dbf.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
-            dbf.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.LOAD_EXTERNAL_DTD_FEATURE, false);
-        } catch (ParserConfigurationException e) {
-            logger.error(
-                    "Failed to load XML Processor Feature " + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE + " or " +
-                    Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE + " or " + Constants.LOAD_EXTERNAL_DTD_FEATURE);
-        }
-
-        SecurityManager securityManager = new SecurityManager();
-        securityManager.setEntityExpansionLimit(ENTITY_EXPANSION_LIMIT);
-        dbf.setAttribute(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
-
-        return dbf;
     }
 }

--- a/modules/balana-core/src/main/java/org/wso2/balana/ConfigurationStore.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/ConfigurationStore.java
@@ -86,6 +86,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.wso2.balana.utils.Utils;
 import org.xml.sax.SAXException;
 
 import org.w3c.dom.Document;
@@ -306,7 +307,7 @@ public class ConfigurationStore {
      * Private helper that parses the file and sets up the DOM tree.
      */
     private Node getRootNode(File configFile) throws ParsingException {
-        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbFactory = Utils.getSecuredDocumentBuilder();
 
         dbFactory.setIgnoringComments(true);
         dbFactory.setNamespaceAware(false);

--- a/modules/balana-core/src/main/java/org/wso2/balana/ctx/InputParser.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/ctx/InputParser.java
@@ -49,6 +49,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import org.wso2.balana.utils.Utils;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -114,7 +115,7 @@ public class InputParser implements ErrorHandler {
         NodeList nodes = null;
 
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = Utils.getSecuredDocumentBuilder();
             factory.setIgnoringComments(true);
 
             DocumentBuilder builder = null;

--- a/modules/balana-core/src/main/java/org/wso2/balana/finder/impl/FileBasedPolicyFinderModule.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/finder/impl/FileBasedPolicyFinderModule.java
@@ -28,6 +28,7 @@ import org.wso2.balana.ctx.Status;
 import org.wso2.balana.finder.PolicyFinder;
 import org.wso2.balana.finder.PolicyFinderModule;
 import org.wso2.balana.finder.PolicyFinderResult;
+import org.wso2.balana.utils.Utils;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -209,7 +210,7 @@ public class FileBasedPolicyFinderModule extends PolicyFinderModule{
 
         try {
             // create the factory
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = Utils.getSecuredDocumentBuilder();
             factory.setIgnoringComments(true);
             factory.setNamespaceAware(true);
             factory.setValidating(false);

--- a/modules/balana-core/src/main/java/org/wso2/balana/finder/impl/SelectorModule.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/finder/impl/SelectorModule.java
@@ -60,6 +60,7 @@ import java.util.List;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.wso2.balana.utils.Utils;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
@@ -165,7 +166,7 @@ public class SelectorModule extends AttributeFinderModule {
                 if(contextNode != null){
                     // make the node appear to be a direct child of the Document
                     try{
-                        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                        DocumentBuilderFactory dbf = Utils.getSecuredDocumentBuilder();
                         DocumentBuilder builder = dbf.newDocumentBuilder();
                         dbf.setNamespaceAware(true);
                         Document docRoot = builder.newDocument();

--- a/modules/balana-core/src/main/java/org/wso2/balana/xacml3/Attributes.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/xacml3/Attributes.java
@@ -21,6 +21,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.wso2.balana.*;
 import org.wso2.balana.ctx.Attribute;
+import org.wso2.balana.utils.Utils;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -138,7 +139,7 @@ public class Attributes {
         if(content != null){
             // make the node appear to be a direct child of the Document
             try{
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory dbf = Utils.getSecuredDocumentBuilder();
                 DocumentBuilder builder = dbf.newDocumentBuilder();
                 dbf.setNamespaceAware(true);
                 Document docRoot = builder.newDocument();

--- a/modules/balana-utils/pom.xml
+++ b/modules/balana-utils/pom.xml
@@ -25,6 +25,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>xerces.wso2</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -63,6 +67,8 @@
                             javax.xml.transform.dom; version="${imp.pkg.version.javax.xml}",
                             javax.xml.transform.stream; version="${imp.pkg.version.javax.xml}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+                            org.apache.xerces.impl;
+                            org.apache.xerces.util;
                             org.w3c.dom
                         </Import-Package>
                     </instructions>

--- a/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
+++ b/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
@@ -18,6 +18,10 @@
 
 package org.wso2.balana.utils;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.xerces.util.SecurityManager;
+import org.apache.xerces.impl.Constants;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
@@ -37,6 +41,16 @@ import java.io.StringWriter;
  *
  */
 public class Utils {
+
+    /**
+     * Logger instance
+     */
+    private static Log logger = LogFactory.getLog(Utils.class);
+
+    /**
+     * Defines XML Entity Expansion Limit
+     */
+    private static final int ENTITY_EXPANSION_LIMIT = 0;
 
     /**
      * Convert Document element to a String object
@@ -62,12 +76,40 @@ public class Utils {
      */
     public static Document createNewDocument() throws ParserConfigurationException {
 
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = getSecuredDocumentBuilder();
         DocumentBuilder docBuilder = null;
         Document doc = null;
         docBuilder = docFactory.newDocumentBuilder();
         doc = docBuilder.newDocument();
         return doc;
+    }
+
+    /**
+     * Create DocumentBuilderFactory with the XXE prevention measurements
+     *
+     * @return DocumentBuilderFactory instance
+     */
+    public static DocumentBuilderFactory getSecuredDocumentBuilder() {
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        try {
+            dbf.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
+            dbf.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
+            dbf.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.LOAD_EXTERNAL_DTD_FEATURE, false);
+        } catch (ParserConfigurationException e) {
+            logger.error(
+                    "Failed to load XML Processor Feature " + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE + " or " +
+                            Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE + " or " + Constants.LOAD_EXTERNAL_DTD_FEATURE);
+        }
+
+        SecurityManager securityManager = new SecurityManager();
+        securityManager.setEntityExpansionLimit(ENTITY_EXPANSION_LIMIT);
+        dbf.setAttribute(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
+
+        return dbf;
     }
     
     

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
             </dependency>
+            <dependency>
+                <groupId>xerces.wso2</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>${xercesImpl.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -74,6 +79,7 @@
         <exp.pkg.version.balana>${balana.version}</exp.pkg.version.balana>
         <imp.pkg.version.javax.xml.parsers>[0.0.0, 1.0.0)</imp.pkg.version.javax.xml.parsers>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
 
         <!--plugin versions-->
         <bundle.plugin.version>1.4.0</bundle.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
                 <artifactId>xercesImpl</artifactId>
                 <version>${xercesImpl.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.balana</groupId>
+                <artifactId>org.wso2.balana.utils</artifactId>
+                <version>${balana.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -77,6 +82,7 @@
         <junit.version>4.8.2</junit.version>
         <imp.pkg.version.javax.xml>[0.0.0,1.0.0)</imp.pkg.version.javax.xml>
         <exp.pkg.version.balana>${balana.version}</exp.pkg.version.balana>
+        <imp.pkg.version.balana>${balana.version}</imp.pkg.version.balana>
         <imp.pkg.version.javax.xml.parsers>[0.0.0, 1.0.0)</imp.pkg.version.javax.xml.parsers>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>


### PR DESCRIPTION
There were 6 `DocumentBuilderFactory.newInstance()` usages in balana-core and balana-utils (excluding tests)

Introduced a new util in balana-utils named `Utils.getSecuredDocumentBuilder()` to get DocumentBuilderFactory instance which have all XXE prevention measurements.