### PR TITLE
Fixing NPE and throw proper exception

### DIFF
--- a/modules/balana-core/src/main/java/org/wso2/balana/attr/BaseAttributeFactory.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/attr/BaseAttributeFactory.java
@@ -188,7 +188,7 @@ public class BaseAttributeFactory extends AttributeFactory {
         }
 
         if (attributeValue == null) {
-            throw new ParsingException("Invalid request. Couldn't create " + type + " attribute based on DOM node");
+            throw new ParsingException("Could not create " + type + " attribute based on DOM node");
         }
 
         return attributeValue;

--- a/modules/balana-core/src/main/java/org/wso2/balana/attr/BaseAttributeFactory.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/attr/BaseAttributeFactory.java
@@ -171,11 +171,13 @@ public class BaseAttributeFactory extends AttributeFactory {
      */
     public AttributeValue createValue(Node root, String type) throws UnknownIdentifierException,
             ParsingException {
+
+        AttributeValue attributeValue;
         AttributeProxy proxy = (AttributeProxy) (attributeMap.get(type));
 
         if (proxy != null) {
             try {
-                return proxy.getInstance(root);
+                attributeValue =  proxy.getInstance(root);
             } catch (Exception e) {
                 throw new ParsingException("couldn't create " + type
                         + " attribute based on DOM node");
@@ -184,6 +186,12 @@ public class BaseAttributeFactory extends AttributeFactory {
             throw new UnknownIdentifierException("Attributes of type " + type
                     + " aren't supported.");
         }
+
+        if (attributeValue == null) {
+            throw new ParsingException("Invalid request. Couldn't create " + type + " attribute based on DOM node");
+        }
+
+        return attributeValue;
     }
 
     /**


### PR DESCRIPTION
This PR fix NPE [1] which caused by invalid xacml requests.

Even in [StringAttribute](https://github.com/wso2/balana/blob/master/modules/balana-core/src/main/java/org/wso2/balana/attr/StringAttribute.java#L141) class, it's mentioned that it should throw an error, if it cannot find a proper value.

With this fix, it's handling those situations from a common place for all types of [AttributeValue](https://github.com/wso2/balana/blob/master/modules/balana-core/src/main/java/org/wso2/balana/attr/AttributeValue.java) instances by throwing a proper ParsingException and avoid causing NPE later in the execution.

[1]
> java.lang.NullPointerException
> 	at org.wso2.balana.ctx.Attribute.encode(Attribute.java:361)
> 	at org.wso2.balana.xacml3.Attributes.encode(Attributes.java:231)
> 	at org.wso2.balana.ctx.xacml3.Result.encode(Result.java:339)
> 	at org.wso2.balana.ctx.ResponseCtx.encode(ResponseCtx.java:190)
> 	at org.wso2.balana.ctx.ResponseCtx.encode(ResponseCtx.java:166)
> 	at org.wso2.balana.PDP.evaluate(PDP.java:134)
> 	at org.wso2.carbon.identity.entitlement.pdp.EntitlementEngine.test(EntitlementEngine.java:254)
> 	at org.wso2.carbon.identity.entitlement.EntitlementAdminService.doTestRequest(EntitlementAdminService.java:342)