### PR TITLE
Resolved warnings

### DIFF
--- a/modules/balana-core/pom.xml
+++ b/modules/balana-core/pom.xml
@@ -94,8 +94,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             org.wso2.balana.*;version=${exp.pkg.version.balana}
                         </Export-Package>

--- a/modules/balana-utils/pom.xml
+++ b/modules/balana-utils/pom.xml
@@ -54,8 +54,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             org.wso2.balana.utils*;version="${exp.pkg.version.balana}"
                         </Export-Package>


### PR DESCRIPTION
The expression ${pom.artifactId} is deprecated. Please use ${project.artifactId} instead.