### PR TITLE
Fixed run.bat files for samples

### DIFF
--- a/modules/balana-samples/custom-combining-algo/run.bat
+++ b/modules/balana-samples/custom-combining-algo/run.bat
@@ -1,8 +1,9 @@
 @echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 set BALANA_CLASSPATH=.\conf
-FOR %%C in ("\lib\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\lib\%%~nC%%~xC"
-FOR %%D in ("\..\..\balana-core\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\..\balana-core\target\%%~nD%%~xD"
-FOR %%E in ("\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\target\%%~nE%%~xE"
+FOR %%C in (".\..\lib\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\lib\%%~nC%%~xC"
+FOR %%D in (".\..\..\balana-core\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\..\balana-core\target\%%~nD%%~xD"
+FOR %%E in (".\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\target\%%~nE%%~xE"
 set _RUNJAVA="%JAVA_HOME%\bin\java"
 %_RUNJAVA% -cp "%BALANA_CLASSPATH%" org.wso2.balana.samples.custom.algo.Main  %*
 

--- a/modules/balana-samples/hierarchical-resource/run.bat
+++ b/modules/balana-samples/hierarchical-resource/run.bat
@@ -1,8 +1,9 @@
 @echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 set BALANA_CLASSPATH=.\conf
-FOR %%C in ("\lib\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\lib\%%~nC%%~xC"
-FOR %%D in ("\..\..\balana-core\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\..\balana-core\target\%%~nD%%~xD"
-FOR %%E in ("\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\target\%%~nE%%~xE"
+FOR %%C in (".\..\lib\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\lib\%%~nC%%~xC"
+FOR %%D in (".\..\..\balana-core\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\..\balana-core\target\%%~nD%%~xD"
+FOR %%E in (".\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\target\%%~nE%%~xE"
 set _RUNJAVA="%JAVA_HOME%\bin\java"
 %_RUNJAVA% -cp "%BALANA_CLASSPATH%" org.wso2.balana.samples.hierarchical.resource.Main %*
 

--- a/modules/balana-samples/kmarket-trading-sample/run.bat
+++ b/modules/balana-samples/kmarket-trading-sample/run.bat
@@ -1,8 +1,9 @@
 @echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 set BALANA_CLASSPATH=.\conf
-FOR %%C in ("\lib\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\lib\%%~nC%%~xC"
-FOR %%D in ("\..\..\balana-core\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\..\balana-core\target\%%~nD%%~xD"
-FOR %%E in ("\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\target\%%~nE%%~xE"
+FOR %%C in (".\..\lib\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\lib\%%~nC%%~xC"
+FOR %%D in (".\..\..\balana-core\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\..\..\balana-core\target\%%~nD%%~xD"
+FOR %%E in (".\target\*.jar") DO set BALANA_CLASSPATH=!BALANA_CLASSPATH!;".\target\%%~nE%%~xE"
 set _RUNJAVA="%JAVA_HOME%\bin\java"
 %_RUNJAVA% -cp "%BALANA_CLASSPATH%" org.wso2.balana.samples.kmarket.trading.KMarketAccessControl  %*
 


### PR DESCRIPTION
The class paths were set incorrectly and !BALANA_CLASSPATH! is only evaluated if delayed expansion is enabled.

Fixes #67 