### PR TITLE
XACML3 Result is not XSD compliant

### DIFF
--- a/modules/balana-core/src/main/java/org/wso2/balana/ctx/xacml3/Result.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/ctx/xacml3/Result.java
@@ -322,6 +322,13 @@ public class Result extends AbstractResult{
             builder.append("</AssociatedAdvice>");
         }
 
+        // encode the attributes
+        if (attributes != null && attributes.size() != 0) {
+            for (Attributes attribute : attributes) {
+                attribute.encode(builder);
+            }
+        }
+
         // encode the policy, policySet references
         if (policyReferences != null  && policyReferences.size() != 0) {
             builder.append("<PolicyIdentifierList>");
@@ -331,13 +338,6 @@ public class Result extends AbstractResult{
             }
 
             builder.append("</PolicyIdentifierList>");
-        }
-
-        // encode the attributes
-        if (attributes != null  && attributes.size() != 0) {
-            for(Attributes attribute : attributes){
-                attribute.encode(builder);
-            }
         }
 
         // finish it off

--- a/modules/balana-core/src/test/java/org/wso2/balana/advance/AdvanceTestV3.java
+++ b/modules/balana-core/src/test/java/org/wso2/balana/advance/AdvanceTestV3.java
@@ -18,6 +18,7 @@
 package org.wso2.balana.advance;
 
 import junit.framework.TestCase;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.balana.*;
@@ -28,8 +29,16 @@ import org.wso2.balana.finder.impl.FileBasedPolicyFinderModule;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
 
 /**
  * Multiple decision profile test cases
@@ -39,17 +48,17 @@ public class AdvanceTestV3 extends TestCase {
     /**
      * directory name that states the test type
      */
-    private final static String ROOT_DIRECTORY  = "advance";
+    private final static String ROOT_DIRECTORY = "advance";
 
     /**
      * directory name that states XACML version
      */
-    private final static String VERSION_DIRECTORY  = "3";
+    private final static String VERSION_DIRECTORY = "3";
 
     /**
      * the logger we'll use for all messages
      */
-	private static Log log = LogFactory.getLog(AdvanceTestV3.class);
+    private static Log log = LogFactory.getLog(AdvanceTestV3.class);
 
     public void testAdvanceTest0001() throws Exception {
 
@@ -58,30 +67,30 @@ public class AdvanceTestV3 extends TestCase {
         policies.add("TestPolicy_0002.xml");
         log.info("Advance Test 0002 is started. This test is for Jira IDENTITY-416");
 
-        for(int i = 1; i < 2 ; i++){
+        for (int i = 1; i < 2; i++) {
 
-            if(i < 10){
+            if (i < 10) {
                 reqResNo = "0" + i;
             } else {
                 reqResNo = Integer.toString(i);
             }
 
             String request = TestUtil.createRequest(ROOT_DIRECTORY, VERSION_DIRECTORY,
-                                                        "request_0002_" + reqResNo + ".xml");
-            if(request != null){
+                    "request_0002_" + reqResNo + ".xml");
+            if (request != null) {
                 log.info("Request that is sent to the PDP :  " + request);
                 ResponseCtx response = TestUtil.evaluate(getPDPNewInstance(policies), request);
-                if(response != null){
+                if (response != null) {
                     log.info("Response that is received from the PDP :  " + response.encode());
                     ResponseCtx expectedResponseCtx = TestUtil.createResponse(ROOT_DIRECTORY,
-                                    VERSION_DIRECTORY, "response_0002_" + reqResNo + ".xml");
-                    if(expectedResponseCtx != null){
+                            VERSION_DIRECTORY, "response_0002_" + reqResNo + ".xml");
+                    if (expectedResponseCtx != null) {
                         assertTrue(TestUtil.isMatching(response, expectedResponseCtx));
                     } else {
-                        assertTrue("Response read from file is Null",false);
+                        assertTrue("Response read from file is Null", false);
                     }
                 } else {
-                    assertFalse("Response received PDP is Null",false);
+                    assertFalse("Response received PDP is Null", false);
                 }
             } else {
                 assertTrue("Request read from file is Null", false);
@@ -98,9 +107,9 @@ public class AdvanceTestV3 extends TestCase {
         policies.add("TestPolicy_0003.xml");
         log.info("Advance Test 0003 is started. This test is for Jira COMMONS-97");
 
-        for(int i = 1; i < 2 ; i++){
+        for (int i = 1; i < 2; i++) {
 
-            if(i < 10){
+            if (i < 10) {
                 reqResNo = "0" + i;
             } else {
                 reqResNo = Integer.toString(i);
@@ -108,20 +117,20 @@ public class AdvanceTestV3 extends TestCase {
 
             String request = TestUtil.createRequest(ROOT_DIRECTORY, VERSION_DIRECTORY,
                     "request_0003_" + reqResNo + ".xml");
-            if(request != null){
+            if (request != null) {
                 log.info("Request that is sent to the PDP :  " + request);
                 ResponseCtx response = TestUtil.evaluate(getPDPNewInstance(policies), request);
-                if(response != null){
+                if (response != null) {
                     log.info("Response that is received from the PDP :  " + response.encode());
                     ResponseCtx expectedResponseCtx = TestUtil.createResponse(ROOT_DIRECTORY,
                             VERSION_DIRECTORY, "response_0003_" + reqResNo + ".xml");
-                    if(expectedResponseCtx != null){
+                    if (expectedResponseCtx != null) {
                         assertTrue(TestUtil.isMatching(response, expectedResponseCtx));
                     } else {
-                        assertTrue("Response read from file is Null",false);
+                        assertTrue("Response read from file is Null", false);
                     }
                 } else {
-                    assertFalse("Response received PDP is Null",false);
+                    assertFalse("Response received PDP is Null", false);
                 }
             } else {
                 assertTrue("Request read from file is Null", false);
@@ -131,18 +140,59 @@ public class AdvanceTestV3 extends TestCase {
         }
     }
 
+
+    public void testAdvanceTest0004() throws Exception {
+
+        String reqResNo;
+        Set<String> policies = new HashSet<String>();
+        policies.add("TestPolicy_0004.xml");
+        log.info("Advance Test 0004 is started. This test is for Jira https://github.com/wso2/balana/issues/73");
+
+        String request = TestUtil.createRequest(ROOT_DIRECTORY, VERSION_DIRECTORY,
+                "request_0004_01.xml");
+        if (request != null) {
+            log.info("Request that is sent to the PDP :  " + request);
+            ResponseCtx response = TestUtil.evaluate(getPDPNewInstance(policies), request);
+            if (response != null) {
+                log.info("Response that is received from the PDP :  " + response.encode());
+                ResponseCtx expectedResponseCtx = TestUtil.createResponse(ROOT_DIRECTORY,
+                        VERSION_DIRECTORY, "response_0004_01.xml");
+                validate(response);
+                if (expectedResponseCtx != null) {
+                    assertTrue(TestUtil.isMatching(response, expectedResponseCtx));
+                } else {
+                    assertTrue("Response read from file is Null", false);
+                }
+            } else {
+                assertFalse("Response received PDP is Null", false);
+            }
+        } else {
+            assertTrue("Request read from file is Null", false);
+        }
+
+        log.info("Advance Test 0004 is finished");
+
+    }
+
+    private static void validate(ResponseCtx ctx) throws Exception {
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = factory.newSchema(new Source[]{new StreamSource(AdvanceTestV3.class.getResource("/xsd/xacml-core-v3-schema-wd-17.xsd").toExternalForm())});
+        Validator validator = schema.newValidator();
+        validator.validate(new StreamSource(new StringReader(ctx.encode())));
+    }
+
     /**
      * Returns a new PDP instance with new XACML policies
      *
-     * @param policies  Set of XACML policy file names
+     * @param policies Set of XACML policy file names
      * @return a  PDP instance
      */
-    private static PDP getPDPNewInstance(Set<String> policies){
+    private static PDP getPDPNewInstance(Set<String> policies) {
 
-        PolicyFinder finder= new PolicyFinder();
+        PolicyFinder finder = new PolicyFinder();
         Set<String> policyLocations = new HashSet<String>();
 
-        for(String policy : policies){
+        for (String policy : policies) {
             try {
                 String policyPath = (new File(".")).getCanonicalPath() + File.separator +
                         TestConstants.RESOURCE_PATH + File.separator + ROOT_DIRECTORY + File.separator +
@@ -150,7 +200,7 @@ public class AdvanceTestV3 extends TestCase {
                         File.separator + policy;
                 policyLocations.add(policyPath);
             } catch (IOException e) {
-               //ignore.
+                //ignore.
             }
         }
 
@@ -162,7 +212,7 @@ public class AdvanceTestV3 extends TestCase {
         Balana balana = Balana.getInstance();
         PDPConfig pdpConfig = balana.getPdpConfig();
         pdpConfig = new PDPConfig(pdpConfig.getAttributeFinder(), finder,
-                                                            pdpConfig.getResourceFinder(), true);
+                pdpConfig.getResourceFinder(), true);
         return new PDP(pdpConfig);
 
     }

--- a/modules/balana-core/src/test/resources/advance/3/policies/TestPolicy_0004.xml
+++ b/modules/balana-core/src/test/resources/advance/3/policies/TestPolicy_0004.xml
@@ -1,0 +1,75 @@
+<Policy xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17 http://docs.oasis-open.org/xacml/3.0/xacml-core-v3-schema-wd-17.xsd" PolicyId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:policy" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:deny-overrides" Version="1.0" xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Description>
+        Policy for Conformance Test IIIA001.
+    </Description>
+    <Target />
+    <Rule RuleId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:rule1" Effect="Deny">
+        <Description>
+            A subject whose name is J. Hibbert may not
+            read Bart Simpson's medical record.  NOTAPPLICABLE
+        </Description>
+        <Target>
+            <AnyOf>
+                <AllOf>
+                    <Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">J. Hibbert</AttributeValue>
+                        <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-id" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" />
+                    </Match>
+                </AllOf>
+            </AnyOf>
+        </Target>
+    </Rule>
+    <Rule RuleId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:rule2" Effect="Permit">
+        <Description>
+            A subject who is at least 5 years older than Bart
+            Simpson may read Bart Simpson's medical record. PERMIT.
+        </Description>
+        <Condition>
+            <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:integer-greater-than-or-equal">
+                <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:integer-subtract">
+                    <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:integer-one-and-only">
+                        <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:age" DataType="http://www.w3.org/2001/XMLSchema#integer" MustBePresent="false" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" />
+                    </Apply>
+                    <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:integer-one-and-only">
+                        <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:bart-simpson-age" DataType="http://www.w3.org/2001/XMLSchema#integer" MustBePresent="false" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:environment" />
+                    </Apply>
+                </Apply>
+                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">5</AttributeValue>
+            </Apply>
+        </Condition>
+    </Rule>
+    <ObligationExpressions>
+        <ObligationExpression ObligationId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:obligation-1" FulfillOn="Permit">
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1" DataType="http://www.w3.org/2001/XMLSchema#string">assignment1</AttributeValue>
+            </AttributeAssignmentExpression>
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2" DataType="http://www.w3.org/2001/XMLSchema#string">assignment2</AttributeValue>
+            </AttributeAssignmentExpression>
+        </ObligationExpression>
+        <ObligationExpression ObligationId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:obligation-2" FulfillOn="Permit">
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1" DataType="http://www.w3.org/2001/XMLSchema#string">assignment1</AttributeValue>
+            </AttributeAssignmentExpression>
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2" DataType="http://www.w3.org/2001/XMLSchema#string">assignment2</AttributeValue>
+            </AttributeAssignmentExpression>
+        </ObligationExpression>
+        <ObligationExpression ObligationId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:obligation-3" FulfillOn="Deny">
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1" DataType="http://www.w3.org/2001/XMLSchema#string">assignment1</AttributeValue>
+            </AttributeAssignmentExpression>
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2" DataType="http://www.w3.org/2001/XMLSchema#string">assignment2</AttributeValue>
+            </AttributeAssignmentExpression>
+        </ObligationExpression>
+        <ObligationExpression ObligationId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:obligation-4" FulfillOn="Deny">
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1" DataType="http://www.w3.org/2001/XMLSchema#string">assignment1</AttributeValue>
+            </AttributeAssignmentExpression>
+            <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2">
+                <AttributeValue AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2" DataType="http://www.w3.org/2001/XMLSchema#string">assignment2</AttributeValue>
+            </AttributeAssignmentExpression>
+        </ObligationExpression>
+    </ObligationExpressions>
+</Policy>

--- a/modules/balana-core/src/test/resources/advance/3/requests/request_0004_01.xml
+++ b/modules/balana-core/src/test/resources/advance/3/requests/request_0004_01.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Request xsi:schemaLocation="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17 http://docs.oasis-open.org/xacml/3.0/xacml-core-v3-schema-wd-17.xsd" ReturnPolicyIdList="true" CombinedDecision="false" xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Attributes Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject">
+    <Attribute IncludeInResult="true" AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-id">
+      <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Julius Hibbert</AttributeValue>
+    </Attribute>
+    <Attribute IncludeInResult="true" AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:age">
+      <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">45</AttributeValue>
+    </Attribute>
+  </Attributes>
+  <Attributes Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource">
+    <Attribute IncludeInResult="false" AttributeId="urn:oasis:names:tc:xacml:1.0:resource:resource-id">
+      <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#anyURI">http://medico.com/record/patient/BartSimpson</AttributeValue>
+    </Attribute>
+  </Attributes>
+  <Attributes Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action">
+    <Attribute IncludeInResult="true" AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id">
+      <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</AttributeValue>
+    </Attribute>
+  </Attributes>
+  <Attributes Category="urn:oasis:names:tc:xacml:3.0:attribute-category:environment">
+    <Attribute IncludeInResult="true" AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:bart-simpson-age">
+      <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">10</AttributeValue>
+    </Attribute>
+  </Attributes>
+</Request>

--- a/modules/balana-core/src/test/resources/advance/3/responses/response_0004_01.xml
+++ b/modules/balana-core/src/test/resources/advance/3/responses/response_0004_01.xml
@@ -1,0 +1,42 @@
+<Response xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+    <Result>
+        <Decision>Permit</Decision>
+        <Status>
+            <StatusCode Value="urn:oasis:names:tc:xacml:1.0:status:ok"/>
+        </Status>
+        <Obligations>
+            <Obligation ObligationId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:obligation-1">
+                <AttributeAssignment AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1"
+                                     DataType="http://www.w3.org/2001/XMLSchema#string">assignment1</AttributeAssignment>
+                <AttributeAssignment AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2"
+                                     DataType="http://www.w3.org/2001/XMLSchema#string">assignment2</AttributeAssignment>
+            </Obligation>
+            <Obligation ObligationId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:obligation-2">
+                <AttributeAssignment AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment1"
+                                     DataType="http://www.w3.org/2001/XMLSchema#string">assignment1</AttributeAssignment>
+                <AttributeAssignment AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:assignment2"
+                                     DataType="http://www.w3.org/2001/XMLSchema#string">assignment2</AttributeAssignment>
+            </Obligation>
+        </Obligations>
+        <Attributes Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action">
+            <Attribute AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" IncludeInResult="true">
+                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</AttributeValue>
+            </Attribute>
+        </Attributes>
+        <Attributes Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject">
+            <Attribute AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:age" IncludeInResult="true">
+                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">45</AttributeValue>
+            </Attribute>
+            <Attribute AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-id" IncludeInResult="true">
+                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Julius Hibbert</AttributeValue>
+            </Attribute>
+        </Attributes>
+        <Attributes Category="urn:oasis:names:tc:xacml:3.0:attribute-category:environment">
+            <Attribute AttributeId="urn:oasis:names:tc:xacml:2.0:conformance-test:bart-simpson-age"
+                       IncludeInResult="true">
+                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">10</AttributeValue>
+            </Attribute>
+        </Attributes>
+        <PolicyIdentifierList><PolicyIdReference>urn:oasis:names:tc:xacml:2.0:conformance-test:IIIA001:policy</PolicyIdReference></PolicyIdentifierList>
+    </Result>
+</Response>

--- a/modules/balana-core/src/test/resources/xsd/xacml-core-v3-schema-wd-17.xsd
+++ b/modules/balana-core/src/test/resources/xsd/xacml-core-v3-schema-wd-17.xsd
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright OASIS Open 2010. All Rights Reserved. -->
+<xs:schema xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace"
+		schemaLocation="xml.xsd"/>
+
+	<xs:element name="Request" type="xacml:RequestType"/>
+	<xs:complexType name="RequestType">
+		<xs:sequence>
+			<xs:element ref="xacml:RequestDefaults" minOccurs="0"/>
+			<xs:element ref="xacml:Attributes" maxOccurs="unbounded"/>
+			<xs:element ref="xacml:MultiRequests" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="ReturnPolicyIdList" type="xs:boolean" use="required" />
+		<xs:attribute name="CombinedDecision" type="xs:boolean" use="required" />
+	</xs:complexType>
+
+	<xs:element name="RequestDefaults" type="xacml:RequestDefaultsType"/>
+	<xs:complexType name="RequestDefaultsType">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element ref="xacml:XPathVersion"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="Response" type="xacml:ResponseType"/>
+	<xs:complexType name="ResponseType">
+		<xs:sequence>
+			<xs:element ref="xacml:Result" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="Content" type="xacml:ContentType"/>
+	<xs:complexType name="ContentType" mixed="true">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="Result" type="xacml:ResultType"/>
+	<xs:complexType name="ResultType">
+		<xs:sequence>
+			<xs:element ref="xacml:Decision"/>
+			<xs:element ref="xacml:Status" minOccurs="0"/>
+			<xs:element ref="xacml:Obligations" minOccurs="0"/>
+			<xs:element ref="xacml:AssociatedAdvice" minOccurs="0"/>
+			<xs:element ref="xacml:Attributes" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="xacml:PolicyIdentifierList" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="PolicyIdentifierList" type="xacml:PolicyIdentifierListType"/>
+	<xs:complexType name="PolicyIdentifierListType">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="xacml:PolicyIdReference"/>
+			<xs:element ref="xacml:PolicySetIdReference"/>
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:element name="Decision" type="xacml:DecisionType"/>
+	<xs:simpleType name="DecisionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Permit"/>
+			<xs:enumeration value="Deny"/>
+			<xs:enumeration value="Indeterminate"/>
+			<xs:enumeration value="NotApplicable"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:element name="Status" type="xacml:StatusType"/>
+	<xs:complexType name="StatusType">
+		<xs:sequence>
+			<xs:element ref="xacml:StatusCode"/>
+			<xs:element ref="xacml:StatusMessage" minOccurs="0"/>
+			<xs:element ref="xacml:StatusDetail" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="StatusCode" type="xacml:StatusCodeType"/>
+	<xs:complexType name="StatusCodeType">
+		<xs:sequence>
+			<xs:element ref="xacml:StatusCode" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="Value" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="StatusMessage" type="xs:string"/>
+
+	<xs:element name="StatusDetail" type="xacml:StatusDetailType"/>
+	<xs:complexType name="StatusDetailType">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="MissingAttributeDetail" type="xacml:MissingAttributeDetailType"/>
+	<xs:complexType name="MissingAttributeDetailType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Category" type="xs:anyURI" use="required"/>
+		<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+	</xs:complexType>
+
+	<xs:element name="Attributes" type="xacml:AttributesType"/>
+	<xs:complexType name="AttributesType">
+		<xs:sequence>
+			<xs:element ref="xacml:Content" minOccurs="0"/>
+			<xs:element ref="xacml:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="Category" type="xs:anyURI" use="required"/>
+		<xs:attribute ref="xml:id" use="optional"/>
+	</xs:complexType>
+
+	<xs:element name="Attribute" type="xacml:AttributeType"/>
+	<xs:complexType name="AttributeType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+		<xs:attribute name="IncludeInResult" type="xs:boolean" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="MultiRequests" type="xacml:MultiRequestsType"/>
+	<xs:complexType name="MultiRequestsType">
+		<xs:sequence>
+			<xs:element ref="xacml:RequestReference" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="RequestReference" type="xacml:RequestReferenceType"/>
+	<xs:complexType name="RequestReferenceType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributesReference" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:element name="AttributesReference" type="xacml:AttributesReferenceType"/>
+	<xs:complexType name="AttributesReferenceType">
+		<xs:attribute name="ReferenceId" type="xs:IDREF" use="required" />
+	</xs:complexType>
+	
+	<xs:element name="Obligations" type="xacml:ObligationsType"/>
+	<xs:complexType name="ObligationsType">
+		<xs:sequence>
+			<xs:element ref="xacml:Obligation" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="AssociatedAdvice" type="xacml:AssociatedAdviceType"/>
+	<xs:complexType name="AssociatedAdviceType">
+		<xs:sequence>
+			<xs:element ref="xacml:Advice" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="Obligation" type="xacml:ObligationType"/>
+	<xs:complexType name="ObligationType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeAssignment" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="ObligationId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="Advice" type="xacml:AdviceType"/>
+	<xs:complexType name="AdviceType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeAssignment" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="AdviceId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="AttributeAssignment" type="xacml:AttributeAssignmentType"/>
+	<xs:complexType name="AttributeAssignmentType" mixed="true">
+		<xs:complexContent mixed="true">
+			<xs:extension base="xacml:AttributeValueType">
+				<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+				<xs:attribute name="Category" type="xs:anyURI" use="optional"/>
+				<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="ObligationExpressions" type="xacml:ObligationExpressionsType"/>
+	<xs:complexType name="ObligationExpressionsType">
+		<xs:sequence>
+			<xs:element ref="xacml:ObligationExpression" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="AdviceExpressions" type="xacml:AdviceExpressionsType"/>
+	<xs:complexType name="AdviceExpressionsType">
+		<xs:sequence>
+			<xs:element ref="xacml:AdviceExpression" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="ObligationExpression" type="xacml:ObligationExpressionType"/>
+	<xs:complexType name="ObligationExpressionType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeAssignmentExpression" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="ObligationId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="FulfillOn" type="xacml:EffectType" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="AdviceExpression" type="xacml:AdviceExpressionType"/>
+	<xs:complexType name="AdviceExpressionType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeAssignmentExpression" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="AdviceId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="AppliesTo" type="xacml:EffectType" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="AttributeAssignmentExpression" type="xacml:AttributeAssignmentExpressionType"/>
+	<xs:complexType name="AttributeAssignmentExpressionType">
+		<xs:sequence>
+			<xs:element ref="xacml:Expression"/>
+		</xs:sequence>
+		<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Category" type="xs:anyURI" use="optional"/>
+		<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+	</xs:complexType>
+
+	<xs:simpleType name="EffectType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Permit"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:element name="PolicySet" type="xacml:PolicySetType"/>
+	<xs:complexType name="PolicySetType">
+		<xs:sequence>
+			<xs:element ref="xacml:Description" minOccurs="0"/>
+			<xs:element ref="xacml:PolicyIssuer" minOccurs="0"/>
+			<xs:element ref="xacml:PolicySetDefaults" minOccurs="0"/>
+			<xs:element ref="xacml:Target"/>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="xacml:PolicySet"/>
+				<xs:element ref="xacml:Policy"/>
+				<xs:element ref="xacml:PolicySetIdReference"/>
+				<xs:element ref="xacml:PolicyIdReference"/>
+				<xs:element ref="xacml:CombinerParameters"/>
+				<xs:element ref="xacml:PolicyCombinerParameters"/>
+				<xs:element ref="xacml:PolicySetCombinerParameters"/>
+			</xs:choice>
+			<xs:element ref="xacml:ObligationExpressions" minOccurs="0"/>
+			<xs:element ref="xacml:AdviceExpressions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="PolicySetId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Version" type="xacml:VersionType" use="required"/>
+		<xs:attribute name="PolicyCombiningAlgId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="MaxDelegationDepth" type="xs:integer" use="optional"/>
+	</xs:complexType>
+
+	<xs:element name="PolicyIssuer" type="xacml:PolicyIssuerType"/>
+	<xs:complexType name="PolicyIssuerType">
+		<xs:sequence>
+            <xs:element ref="xacml:Content" minOccurs="0"/>
+			<xs:element ref="xacml:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="CombinerParameters" type="xacml:CombinerParametersType"/>
+	<xs:complexType name="CombinerParametersType">
+		<xs:sequence>
+			<xs:element ref="xacml:CombinerParameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="CombinerParameter" type="xacml:CombinerParameterType"/>
+	<xs:complexType name="CombinerParameterType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+		</xs:sequence>
+		<xs:attribute name="ParameterName" type="xs:string" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="RuleCombinerParameters" type="xacml:RuleCombinerParametersType"/>
+	<xs:complexType name="RuleCombinerParametersType">
+		<xs:complexContent>
+			<xs:extension base="xacml:CombinerParametersType">
+				<xs:attribute name="RuleIdRef" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="PolicyCombinerParameters" type="xacml:PolicyCombinerParametersType"/>
+	<xs:complexType name="PolicyCombinerParametersType">
+		<xs:complexContent>
+			<xs:extension base="xacml:CombinerParametersType">
+				<xs:attribute name="PolicyIdRef" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="PolicySetCombinerParameters" type="xacml:PolicySetCombinerParametersType"/>
+	<xs:complexType name="PolicySetCombinerParametersType">
+		<xs:complexContent>
+			<xs:extension base="xacml:CombinerParametersType">
+				<xs:attribute name="PolicySetIdRef" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="PolicySetIdReference" type="xacml:IdReferenceType"/>
+	<xs:element name="PolicyIdReference" type="xacml:IdReferenceType"/>
+
+	<xs:element name="PolicySetDefaults" type="xacml:DefaultsType"/>
+	<xs:element name="PolicyDefaults" type="xacml:DefaultsType"/>
+	<xs:complexType name="DefaultsType">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element ref="xacml:XPathVersion"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="XPathVersion" type="xs:anyURI"/>
+
+	<xs:complexType name="IdReferenceType">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:attribute name="Version" type="xacml:VersionMatchType" use="optional"/>
+				<xs:attribute name="EarliestVersion" type="xacml:VersionMatchType" use="optional"/>
+				<xs:attribute name="LatestVersion" type="xacml:VersionMatchType" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:simpleType name="VersionType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="(\d+\.)*\d+"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="VersionMatchType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="((\d+|\*)\.)*(\d+|\*|\+)"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:element name="Policy" type="xacml:PolicyType"/>
+	<xs:complexType name="PolicyType">
+		<xs:sequence>
+			<xs:element ref="xacml:Description" minOccurs="0"/>
+			<xs:element ref="xacml:PolicyIssuer" minOccurs="0"/>
+			<xs:element ref="xacml:PolicyDefaults" minOccurs="0"/>
+			<xs:element ref="xacml:Target"/>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="xacml:CombinerParameters" minOccurs="0"/>
+				<xs:element ref="xacml:RuleCombinerParameters" minOccurs="0"/>
+				<xs:element ref="xacml:VariableDefinition"/>
+				<xs:element ref="xacml:Rule"/>
+			</xs:choice>
+			<xs:element ref="xacml:ObligationExpressions" minOccurs="0"/>
+			<xs:element ref="xacml:AdviceExpressions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="PolicyId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="Version" type="xacml:VersionType" use="required"/>
+		<xs:attribute name="RuleCombiningAlgId" type="xs:anyURI" use="required"/>
+		<xs:attribute name="MaxDelegationDepth" type="xs:integer" use="optional"/>
+	</xs:complexType>
+
+	<xs:element name="Description" type="xs:string"/>
+
+	<xs:element name="Rule" type="xacml:RuleType"/>
+	<xs:complexType name="RuleType">
+		<xs:sequence>
+			<xs:element ref="xacml:Description" minOccurs="0"/>
+			<xs:element ref="xacml:Target" minOccurs="0"/>
+			<xs:element ref="xacml:Condition" minOccurs="0"/>
+			<xs:element ref="xacml:ObligationExpressions" minOccurs="0"/>
+			<xs:element ref="xacml:AdviceExpressions" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="RuleId" type="xs:string" use="required"/>
+		<xs:attribute name="Effect" type="xacml:EffectType" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="Target" type="xacml:TargetType"/>
+	<xs:complexType name="TargetType">
+		<xs:sequence minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="xacml:AnyOf"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="AnyOf" type="xacml:AnyOfType"/>
+	<xs:complexType name="AnyOfType">
+		<xs:sequence minOccurs="1" maxOccurs="unbounded">
+			<xs:element ref="xacml:AllOf"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="AllOf" type="xacml:AllOfType"/>
+	<xs:complexType name="AllOfType">
+		<xs:sequence minOccurs="1" maxOccurs="unbounded">
+			<xs:element ref="xacml:Match"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="Match" type="xacml:MatchType"/>
+	<xs:complexType name="MatchType">
+		<xs:sequence>
+			<xs:element ref="xacml:AttributeValue"/>
+			<xs:choice>
+				<xs:element ref="xacml:AttributeDesignator"/>
+				<xs:element ref="xacml:AttributeSelector"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="MatchId" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="VariableDefinition" type="xacml:VariableDefinitionType"/>
+	<xs:complexType name="VariableDefinitionType">
+		<xs:sequence>
+			<xs:element ref="xacml:Expression"/>
+		</xs:sequence>
+		<xs:attribute name="VariableId" type="xs:string" use="required"/>
+	</xs:complexType>
+
+	<xs:element name="Expression" type="xacml:ExpressionType" abstract="true"/>
+	<xs:complexType name="ExpressionType" abstract="true"/>
+
+	<xs:element name="VariableReference" type="xacml:VariableReferenceType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="VariableReferenceType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="VariableId" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="AttributeSelector" type="xacml:AttributeSelectorType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="AttributeSelectorType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="Category" type="xs:anyURI" use="required"/>
+				<xs:attribute name="ContextSelectorId" type="xs:anyURI" use="optional"/>
+				<xs:attribute name="Path" type="xs:string" use="required"/>
+				<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+				<xs:attribute name="MustBePresent" type="xs:boolean" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="AttributeDesignator" type="xacml:AttributeDesignatorType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="AttributeDesignatorType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="Category" type="xs:anyURI" use="required"/>
+				<xs:attribute name="AttributeId" type="xs:anyURI" use="required"/>
+				<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+				<xs:attribute name="Issuer" type="xs:string" use="optional"/>
+				<xs:attribute name="MustBePresent" type="xs:boolean" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="AttributeValue" type="xacml:AttributeValueType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="AttributeValueType" mixed="true">
+		<xs:complexContent mixed="true">
+			<xs:extension base="xacml:ExpressionType">
+				<xs:sequence>
+					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="DataType" type="xs:anyURI" use="required"/>
+				<xs:anyAttribute namespace="##any" processContents="lax"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="Function" type="xacml:FunctionType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="FunctionType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:attribute name="FunctionId" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="Condition" type="xacml:ConditionType"/>
+	<xs:complexType name="ConditionType">
+		<xs:sequence>
+			<xs:element ref="xacml:Expression"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="Apply" type="xacml:ApplyType" substitutionGroup="xacml:Expression"/>
+	<xs:complexType name="ApplyType">
+		<xs:complexContent>
+			<xs:extension base="xacml:ExpressionType">
+				<xs:sequence>
+					<xs:element ref="xacml:Description" minOccurs="0"/>
+					<xs:element ref="xacml:Expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="FunctionId" type="xs:anyURI" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+</xs:schema>

--- a/modules/balana-core/src/test/resources/xsd/xml.xsd
+++ b/modules/balana-core/src/test/resources/xsd/xml.xsd
@@ -1,0 +1,145 @@
+<?xml version='1.0'?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    id   (as an attribute name): denotes an attribute whose value
+         should be interpreted as if declared to be of type ID.
+         This name is reserved by virtue of its definition in the
+         xml:id specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang, xml:space or xml:id
+        attributes on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2007/08/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself, or with the XML namespace itself.  In other words, if the XML
+   Schema or XML namespaces change, the version of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2007/08/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>Attempting to install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values is probably never
+         going to be a realistic possibility.  See
+         RFC 3066 at http://www.ietf.org/rfc/rfc3066.txt and the IANA registry
+         at http://www.iana.org/assignments/lang-tag-apps.htm for
+         further information.
+
+         The union allows for the 'un-declaration' of xml:lang with
+         the empty string.</xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xml-id/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+</xs:schema>


### PR DESCRIPTION
Description:
When balana is generating a XACML 3.0 it is not XSD compliant. The element order should be
Decision, Status , Obligations, AssociatedAdvise, Attributes and PolicyIdentifierList. Balana puts the Attributes after the PolicyIdentifierList.

Affected Product Version:
Latest release and snapshot

Steps to reproduce:
Validate a full blown XACML Response through an XML validator.