### PR TITLE
Updated external references to xacmlinfo.org instead of xacmlinfo.com

### DIFF
--- a/modules/balana-samples/custom-combining-algo/README.txt
+++ b/modules/balana-samples/custom-combining-algo/README.txt
@@ -12,5 +12,5 @@ If user name is given as "alice". Policy with two  "Permit" rules  and three "De
 
 If user name is given as "peter". Policy with two  "Permit" rules and two "Deny"  rules and one "Not Applicable" rule would be applied. Therefore fine result would be "Deny"
 
-More details - http://xacmlinfo.com/2012/12/18/extending-balana-custom-combining-algorithms/
+More details - http://xacmlinfo.org/2012/12/18/extending-balana-custom-combining-algorithms/
 

--- a/modules/balana-samples/hierarchical-resource/README.txt
+++ b/modules/balana-samples/hierarchical-resource/README.txt
@@ -4,4 +4,4 @@ How to run sample
 1. You need to install java jdk1.6.X or higher
 2. Execute "run" script 
 
-More details - http://xacmlinfo.com/2013/01/09/authorization-for-hierarchical-resources-with-xacml-multiple-decision-profile/
+More details - http://xacmlinfo.org/2013/01/09/authorization-for-hierarchical-resources-with-xacml-multiple-decision-profile/

--- a/modules/balana-samples/kmarket-trading-sample/README.txt
+++ b/modules/balana-samples/kmarket-trading-sample/README.txt
@@ -4,6 +4,6 @@ How to run sample
 1. You need to install java jdk1.6.X or higher
 2. Execute "run" script
 
-More details - http://xacmlinfo.com/2012/08/16/xacml-sample-for-on-line-trading-application/
+More details - http://xacmlinfo.org/2012/08/16/xacml-sample-for-on-line-trading-application/
 
 

--- a/modules/balana-samples/web-page-image-filtering/README.txt
+++ b/modules/balana-samples/web-page-image-filtering/README.txt
@@ -4,4 +4,4 @@ How to run sample
 1. You need to install java jdk1.6.X or higher
 2. Execute "run" script 
 
-More details - http://xacmlinfo.com/2012/08/16/resource-filtering-with-xacml/
+More details - http://xacmlinfo.org/2012/08/16/resource-filtering-with-xacml/


### PR DESCRIPTION
This small patch contains updated references to xacmlinfo.org, as included in Balana Samples.