### PR TITLE
Fix encoding

### DIFF
--- a/modules/balana-core/src/main/java/org/wso2/balana/Rule.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/Rule.java
@@ -467,7 +467,9 @@ public class Rule implements PolicyTreeElement {
     }
 
     public String encode() {
-        return null; // TODO.
+        StringBuilder sb = new StringBuilder();
+        encode(sb);
+        return sb.toString();
     }
 
     public void encode(StringBuilder builder) {

--- a/modules/balana-core/src/main/java/org/wso2/balana/ctx/AttributeAssignment.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/ctx/AttributeAssignment.java
@@ -168,7 +168,7 @@ public class AttributeAssignment extends AttributeValue {
             builder.append("\" Issuer=\"").append(issuer).append("\"");
         }
 
-        builder.append(">\n");
+        builder.append(">");
 
         if(content != null){
             builder.append(content);

--- a/modules/balana-core/src/main/java/org/wso2/balana/ctx/xacml2/RequestCtx.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/ctx/xacml2/RequestCtx.java
@@ -357,7 +357,7 @@ public class RequestCtx extends AbstractRequestCtx {
 
         // Prepare the indentation string
         String topIndent = indenter.makeString();
-        out.println(topIndent + "<Request xmlns=\"" + XACMLConstants.RESOURCE_SCOPE_2_0 + "\" >");
+        out.println(topIndent + "<Request xmlns=\"" + XACMLConstants.REQUEST_CONTEXT_2_0_IDENTIFIER + "\" >");
 
         // go in one more for next-level elements...
         indenter.in();
@@ -433,7 +433,7 @@ public class RequestCtx extends AbstractRequestCtx {
         Iterator it = attributes.iterator();
         while (it.hasNext()) {
             Attribute attr = (Attribute) (it.next());
-            out.println(attr.encode());
+            out.print(indenter.makeString() + attr.encode());
         }
         
         indenter.out();


### PR DESCRIPTION
## Purpose
Fixes wrong encoding of XACML objects

## Goals
* <Rule> elements can be encoded without a StringBuilder
* AttributeAssignments no longer add an unwanted linebreak
* Fixes the XML namespace of XACML 2.0 <Request> elements

## Approach
I've just corrected the existing code so the encoded Strings can be parsed again.

## User stories
No user stories

## Release note
Fixed encoding of <Rule>, <AttributeAssignment> and XACML 2.0 <Request> elements

## Documentation
N/A because there is no documentation

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
No unit tests were written since there are none for encoding methods

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#61 contained the same fixes but was never looked at and just rejected

## Migrations (if applicable)
N/A

## Test environment
Windows 2012, JDK 8
 
## Learning
N/A