### PR TITLE
Make policy's target hierarchy accessible from 'outside world'

### DIFF
--- a/modules/balana-core/src/main/java/org/wso2/balana/xacml3/AllOfSelection.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/xacml3/AllOfSelection.java
@@ -115,6 +115,9 @@ public class AllOfSelection {
 
     }
 
+    public List<TargetMatch> getMatches() {
+        return matches;
+    }
 
     /**
      * Encodes this <code>AnyOfSelection</code> into its XML form and writes this out to the provided

--- a/modules/balana-core/src/main/java/org/wso2/balana/xacml3/AnyOfSelection.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/xacml3/AnyOfSelection.java
@@ -131,6 +131,10 @@ public class AnyOfSelection {
         }
     }
 
+    public List<AllOfSelection> getAllOfSelections() {
+        return allOfSelections;
+    }
+    
     /**
      * Encodes this <code>AnyOfSelection</code> into its XML form and writes this out to the provided
      * <code>StringBuilder<code>


### PR DESCRIPTION
## Purpose
Make private/protected members of AnyOfSelection and AllOfSelection classes accessible via getters methods. This will make the Policy API more consistent. All members over the hierarchy (form Policy to TargetMatch) are public (excluding AnyOfSelection and AllOfSelection properties).

## Goals
Make policy's target hierarchy accessible from 'outside world'.

## Approach
Added getters members.