### PR TITLE
Fix for creating XACML policy in WSO2 IS Key Manager #99

### DIFF
--- a/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
+++ b/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
@@ -60,7 +60,11 @@ public class Utils {
         DOMSource domSource = new DOMSource(doc);
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
-        TransformerFactory transformerFactory = TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl",null);
+        String transformerFactoryClassName = System.getProperty("org.wso2.balana.TransformerFactory");
+        if(transformerFactoryClassName == null) {
+            transformerFactoryClassName = "org.apache.xalan.processor.TransformerFactoryImpl";
+        }
+        TransformerFactory transformerFactory = TransformerFactory.newInstance(transformerFactoryClassName, null);
         Transformer transformer = transformerFactory.newTransformer();
         transformer.transform(domSource, result);
         return writer.toString().substring(writer.toString().indexOf('>') + 1);

--- a/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
+++ b/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
@@ -60,7 +60,6 @@ public class Utils {
         DOMSource domSource = new DOMSource(doc);
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
-        //TransformerFactory transformerFactory = TransformerFactory.newInstance();
         TransformerFactory transformerFactory = TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl",null);
         Transformer transformer = transformerFactory.newTransformer();
         transformer.transform(domSource, result);

--- a/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
+++ b/modules/balana-utils/src/main/java/org/wso2/balana/utils/Utils.java
@@ -60,7 +60,8 @@ public class Utils {
         DOMSource domSource = new DOMSource(doc);
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        //TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        TransformerFactory transformerFactory = TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl",null);
         Transformer transformer = transformerFactory.newTransformer();
         transformer.transform(domSource, result);
         return writer.toString().substring(writer.toString().indexOf('>') + 1);


### PR DESCRIPTION
While creating a XACML policy in WSO2 Identity Server Key Manager, we were facing the following issue.
[https://github.com/wso2/balana/issues/99](https://github.com/wso2/balana/issues/99)

We fixed it by obtaining a new instance of a TransformerFactory from the factory class name :  org.apache.xalan.processor.TransformerFactoryImpl. 

This creates a Xalan processor instance in place of Saxon processor. The policy created is valid and gets added successfully.

Keeping the Saxon-he-9.4 jar at \wso2is-km-5.3.0\lib\endorsed, we verified this fix at our end and everything seems to work fine.
