### PR TITLE
 Implement XACML3 higher order functions. (any-of, all-of and any-of-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 cache:
   directories:
   - .autoconf

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/GeneralBagFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/GeneralBagFunction.java
@@ -278,6 +278,12 @@ public class GeneralBagFunction extends BagFunction {
         return new EvaluationResult(attrResult);
     }
 
+    @Override
+    public final boolean returnsBag() {
+
+        return getReturnsBag(getFunctionName());
+    }
+
     /**
      * Private class that is used for mapping each function to it set of parameters.
      */

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/StandardFunctionFactory.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/StandardFunctionFactory.java
@@ -8,7 +8,7 @@
  *
  *   1. Redistribution of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer.
- * 
+ *
  *   2. Redistribution in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
@@ -16,7 +16,7 @@
  * Neither the name of Sun Microsystems, Inc. or the names of contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * This software is provided "AS IS," without a warranty of any kind. ALL
  * EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING
  * ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
@@ -39,9 +39,35 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.balana.UnknownIdentifierException;
 
-import org.wso2.balana.cond.cluster.*;
+import org.wso2.balana.cond.cluster.AbsFunctionCluster;
+import org.wso2.balana.cond.cluster.AddFunctionCluster;
+import org.wso2.balana.cond.cluster.ComparisonFunctionCluster;
+import org.wso2.balana.cond.cluster.ConditionBagFunctionCluster;
+import org.wso2.balana.cond.cluster.ConditionSetFunctionCluster;
+import org.wso2.balana.cond.cluster.DateMathFunctionCluster;
+import org.wso2.balana.cond.cluster.DivideFunctionCluster;
+import org.wso2.balana.cond.cluster.EqualFunctionCluster;
+import org.wso2.balana.cond.cluster.FloorFunctionCluster;
+import org.wso2.balana.cond.cluster.GeneralBagFunctionCluster;
+import org.wso2.balana.cond.cluster.GeneralSetFunctionCluster;
 import org.wso2.balana.cond.cluster.HigherOrderFunctionCluster;
-import org.wso2.balana.cond.cluster.xacml3.*;
+import org.wso2.balana.cond.cluster.LogicalFunctionCluster;
+import org.wso2.balana.cond.cluster.MatchFunctionCluster;
+import org.wso2.balana.cond.cluster.ModFunctionCluster;
+import org.wso2.balana.cond.cluster.MultiplyFunctionCluster;
+import org.wso2.balana.cond.cluster.NOfFunctionCluster;
+import org.wso2.balana.cond.cluster.NotFunctionCluster;
+import org.wso2.balana.cond.cluster.NumericConvertFunctionCluster;
+import org.wso2.balana.cond.cluster.RoundFunctionCluster;
+import org.wso2.balana.cond.cluster.StringFunctionCluster;
+import org.wso2.balana.cond.cluster.StringNormalizeFunctionCluster;
+import org.wso2.balana.cond.cluster.SubtractFunctionCluster;
+import org.wso2.balana.cond.cluster.xacml3.StringComparingFunctionCluster;
+import org.wso2.balana.cond.cluster.xacml3.StringConversionFunctionCluster;
+import org.wso2.balana.cond.cluster.xacml3.StringCreationFunctionCluster;
+import org.wso2.balana.cond.cluster.xacml3.SubStringFunctionCluster;
+import org.wso2.balana.cond.cluster.xacml3.XACML3HigherOrderFunctionCluster;
+import org.wso2.balana.cond.cluster.xacml3.XPathFunctionCluster;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -63,7 +89,7 @@ import java.util.Set;
  * <code>FunctionFactory</code>) populated with the standard functions from
  * <code>getStandardFunctions</code> or you can use <code>getNewFactoryProxy</code> to get a proxy
  * containing a new, modifiable set of factories.
- * 
+ *
  * @since 1.2
  * @author Seth Proctor
  */
@@ -148,7 +174,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
         // add condition function TimeInRange
         conditionFunctions.add(new TimeInRangeFunction());
         // add condition function IPInRange
-        conditionFunctions.add(new IPInRangeFunction());        
+        conditionFunctions.add(new IPInRangeFunction());
         // add condition functions from BagFunction
         conditionFunctions.addAll((new ConditionBagFunctionCluster()).getSupportedFunctions());
         // add condition functions from SetFunction
@@ -208,9 +234,9 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
         // add the XACML 3.0 start with functions
         generalFunctions.addAll((new SubStringFunctionCluster()).getSupportedFunctions());
         // add the XACML 3.0 start with functions
-        generalFunctions.addAll((new StringCreationFunctionCluster()).getSupportedFunctions());  
+        generalFunctions.addAll((new StringCreationFunctionCluster()).getSupportedFunctions());
         // add the XACML 3.0 start with functions
-        generalFunctions.addAll((new XPathFunctionCluster()).getSupportedFunctions());  
+        generalFunctions.addAll((new XPathFunctionCluster()).getSupportedFunctions());
 
         generalAbstractFunctions = new HashMap<URI, FunctionProxy>(conditionAbstractFunctions); // TODO
 
@@ -228,7 +254,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
      * matching. This method enforces a singleton model, meaning that this always returns the same
      * instance, creating the factory if it hasn't been requested before. This is the default model
      * used by the <code>FunctionFactory</code>, ensuring quick access to this factory.
-     * 
+     *
      * @return a <code>FunctionFactory</code> for target functions
      */
     public static StandardFunctionFactory getTargetFactory() {
@@ -251,7 +277,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
      * enforces a singleton model, meaning that this always returns the same instance, creating the
      * factory if it hasn't been requested before. This is the default model used by the
      * <code>FunctionFactory</code>, ensuring quick access to this factory.
-     * 
+     *
      * @return a <code>FunctionFactory</code> for condition functions
      */
     public static StandardFunctionFactory getConditionFactory() {
@@ -274,7 +300,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
      * this always returns the same instance, creating the factory if it hasn't been requested
      * before. This is the default model used by the <code>FunctionFactory</code>, ensuring quick
      * access to this factory.
-     * 
+     *
      * @return a <code>FunctionFactory</code> for all functions
      */
     public static StandardFunctionFactory getGeneralFactory() {
@@ -295,12 +321,12 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
      * Returns the identifiers supported for the given version of XACML. Because this factory
      * supports identifiers from all versions of the XACML specifications, this method is useful for
      * getting a list of which specific identifiers are supported by a given version of XACML.
-     * 
+     *
      * @param xacmlVersion a standard XACML identifier string, as provided in
      *            <code>PolicyMetaData</code>
-     * 
+     *
      * @return a <code>Set</code> of identifiers
-     * 
+     *
      * @throws UnknownIdentifierException if the version string is unknown
      */
     public static Set getStandardFunctions(String xacmlVersion) {
@@ -311,7 +337,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
     /**
      * Returns the set of abstract functions that this standard factory supports as a mapping of
      * identifier to proxy.
-     * 
+     *
      * @return a <code>Map</code> mapping <code>URI</code>s to <code>FunctionProxy</code>s
      */
     public static Map getStandardAbstractFunctions(String xacmlVersion) {
@@ -323,7 +349,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
      * A convenience method that returns a proxy containing newly created instances of
      * <code>BaseFunctionFactory</code>s that are correctly supersetted and contain the standard
      * functions and abstract functions. These factories allow adding support for new functions.
-     * 
+     *
      * @return a new proxy containing new factories supporting the standard functions
      */
     public static FunctionFactoryProxy getNewFactoryProxy() {
@@ -346,9 +372,9 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
     /**
      * Always throws an exception, since support for new functions may not be added to a standard
      * factory.
-     * 
+     *
      * @param function the <code>Function</code> to add to the factory
-     * 
+     *
      * @throws UnsupportedOperationException always
      */
     public void addFunction(Function function) throws IllegalArgumentException {
@@ -359,10 +385,10 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
     /**
      * Always throws an exception, since support for new functions may not be added to a standard
      * factory.
-     * 
+     *
      * @param proxy the <code>FunctionProxy</code> to add to the factory
      * @param identity the function's identifier
-     * 
+     *
      * @throws UnsupportedOperationException always
      */
     public void addAbstractFunction(FunctionProxy proxy, URI identity)

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/StandardFunctionFactory.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/StandardFunctionFactory.java
@@ -40,6 +40,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.balana.UnknownIdentifierException;
 
 import org.wso2.balana.cond.cluster.*;
+import org.wso2.balana.cond.cluster.HigherOrderFunctionCluster;
 import org.wso2.balana.cond.cluster.xacml3.*;
 
 import java.net.URI;
@@ -154,6 +155,7 @@ public class StandardFunctionFactory extends BaseFunctionFactory {
         conditionFunctions.addAll((new ConditionSetFunctionCluster()).getSupportedFunctions());
         // add condition functions from HigherOrderFunction
         conditionFunctions.addAll((new HigherOrderFunctionCluster()).getSupportedFunctions());
+        conditionFunctions.addAll((new XACML3HigherOrderFunctionCluster()).getSupportedFunctions());
 
         conditionAbstractFunctions = new HashMap<URI, FunctionProxy>(targetAbstractFunctions);// TODO ??
     }

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/cluster/xacml3/XACML3HigherOrderFunctionCluster.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/cluster/xacml3/XACML3HigherOrderFunctionCluster.java
@@ -31,11 +31,11 @@ import java.util.Set;
  */
 public class XACML3HigherOrderFunctionCluster implements FunctionCluster {
 
+    @Override
     public Set<Function> getSupportedFunctions() {
 
         Set<Function> set = new HashSet<>();
         Iterator it = XACML3HigherOrderFunction.getSupportedIdentifiers().iterator();
-
         while (it.hasNext()) {
             set.add(new XACML3HigherOrderFunction((String) (it.next())));
         }

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/cluster/xacml3/XACML3HigherOrderFunctionCluster.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/cluster/xacml3/XACML3HigherOrderFunctionCluster.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 
 package org.wso2.balana.cond.cluster.xacml3;

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/cluster/xacml3/XACML3HigherOrderFunctionCluster.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/cluster/xacml3/XACML3HigherOrderFunctionCluster.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.balana.cond.cluster.xacml3;
+
+import org.wso2.balana.cond.Function;
+import org.wso2.balana.cond.xacml3.XACML3HigherOrderFunction;
+import org.wso2.balana.cond.cluster.FunctionCluster;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Clusters all the functions supported by <code>XACML3HigherOrderFunction</code>.
+ */
+public class XACML3HigherOrderFunctionCluster implements FunctionCluster {
+
+    public Set<Function> getSupportedFunctions() {
+
+        Set<Function> set = new HashSet<>();
+        Iterator it = XACML3HigherOrderFunction.getSupportedIdentifiers().iterator();
+
+        while (it.hasNext()) {
+            set.add(new XACML3HigherOrderFunction((String) (it.next())));
+        }
+        return set;
+    }
+}

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
@@ -1,0 +1,364 @@
+/*
+ *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.balana.cond.xacml3;
+
+import org.wso2.balana.attr.AttributeValue;
+import org.wso2.balana.attr.BagAttribute;
+import org.wso2.balana.attr.BooleanAttribute;
+import org.wso2.balana.cond.Evaluatable;
+import org.wso2.balana.cond.EvaluationResult;
+import org.wso2.balana.cond.Expression;
+import org.wso2.balana.cond.Function;
+import org.wso2.balana.cond.FunctionBase;
+import org.wso2.balana.cond.VariableReference;
+import org.wso2.balana.ctx.EvaluationCtx;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents all of the XACML3 higher order functions. (any-of, all-of and any-of-any)
+ */
+public class XACML3HigherOrderFunction implements Function {
+
+    // Standard identifier for the any-of function.
+    public static final String NAME_ANY_OF = FunctionBase.FUNCTION_NS_3 + "any-of";
+
+    // Standard identifier for the all-of function.
+    public static final String NAME_ALL_OF = FunctionBase.FUNCTION_NS_3 + "all-of";
+
+    // Standard identifier for the any-of-any function.
+    public static final String NAME_ANY_OF_ANY = FunctionBase.FUNCTION_NS_3 + "any-of-any";
+
+    // Internal identifiers for each of the supported functions.
+    private static final int ID_ANY_OF = 0;
+    private static final int ID_ALL_OF = 1;
+    private static final int ID_ANY_OF_ANY = 2;
+
+    // Internal mapping of names to ids.
+    private static HashMap<String, Integer> idMap;
+
+    private int functionId;
+    private URI identifier;
+    private static URI returnTypeURI;
+    private static RuntimeException earlyException;
+
+    // Try to create the return type URI, and also setup the id map.
+    static {
+        try {
+            returnTypeURI = new URI(BooleanAttribute.identifier);
+        } catch (Exception e) {
+            earlyException = new IllegalArgumentException();
+            earlyException.initCause(e);
+        }
+
+        idMap = new HashMap<String, Integer>();
+
+        idMap.put(NAME_ANY_OF, Integer.valueOf(ID_ANY_OF));
+        idMap.put(NAME_ALL_OF, Integer.valueOf(ID_ALL_OF));
+        idMap.put(NAME_ANY_OF_ANY, Integer.valueOf(ID_ANY_OF_ANY));
+    }
+
+    /**
+     * Creates a new instance of the given function.
+     *
+     * @param functionName the function to create
+     * @throws IllegalArgumentException if the function is unknown
+     */
+    public XACML3HigherOrderFunction(String functionName) {
+
+        // Try to get the function's identifier.
+        Integer i = (Integer) (idMap.get(functionName));
+        if (i == null) {
+            throw new IllegalArgumentException("Unknown function: " + functionName);
+        }
+        functionId = i.intValue();
+
+        // Setup the URI form of this function's identity.
+        try {
+            identifier = new URI(functionName);
+        } catch (URISyntaxException use) {
+            throw new IllegalArgumentException("Invalid URI");
+        }
+    }
+
+    /**
+     * Returns a <code>Set</code> containing all the function identifiers supported by this class.
+     *
+     * @return a <code>Set</code> of <code>String</code>s
+     */
+    public static Set getSupportedIdentifiers() {
+
+        return Collections.unmodifiableSet(idMap.keySet());
+    }
+
+    @Override
+    public void checkInputs(List inputs) throws IllegalArgumentException {
+
+        Object[] list = inputs.toArray();
+
+        // First, check that we got the right number of parameters.
+        if (list.length < 2)
+            throw new IllegalArgumentException("requires more than two inputs");
+
+        // Try to cast the first element into a function.
+        Function function = null;
+
+        if (list[0] instanceof Function) {
+            function = (Function) (list[0]);
+        } else {
+            throw new IllegalArgumentException("first arg to higher-order "
+                    + " function must be a function");
+        }
+
+        // Check that the function returns a boolean
+        if (!function.getReturnType().toString().equals(BooleanAttribute.identifier))
+            throw new IllegalArgumentException("higher-order function must "
+                    + "use a boolean function");
+
+        // Separate the remaining inputs into primitive data types or bags of primitive types.
+        List<Evaluatable> bagArgs = new ArrayList();
+        List<Evaluatable> args = new ArrayList();
+        for (int i = 1; i < list.length; i++) {
+            Evaluatable eval = (Evaluatable) (list[i]);
+            if (eval.returnsBag()) {
+                bagArgs.add(eval);
+            } else {
+                args.add(eval);
+            }
+        }
+        if (functionId == ID_ALL_OF || functionId == ID_ANY_OF) {
+            // The n-1 parameters SHALL be values of primitive data-types and one SHALL be a bag of a primitive
+            // data-type for any-of and all-of.
+            if (bagArgs.size() != 1) {
+                throw new IllegalArgumentException("Only one argument SHALL be a bag of a primitive data-type for " +
+                        getIdentifier());
+            }
+            //  The expression SHALL be evaluated as if the function named in the <Function> argument were applied
+            //  to the n-1 non-bag arguments and each element of the bag argument for any-of and all-of.
+            for (Evaluatable arg : args) {
+                List<Evaluatable> inputForCheck = new ArrayList();
+                inputForCheck.add(arg);
+                inputForCheck.addAll(bagArgs);
+                function.checkInputsNoBag(inputForCheck);
+            }
+        } else {
+            // The remaining arguments are either primitive data types or bags of primitive types.
+            if (args.size() > 0 && bagArgs.size() > 0) {
+                throw new IllegalArgumentException("The arguments can be are either primitive data types or " +
+                        "bags of primitive types. " + getIdentifier());
+            }
+            // The expression SHALL be evaluated as if the function named in the <Function> argument was applied
+            // between every tuple of the cross product on all bags and the primitive values.
+            if (args.size() > 0) {
+                validateAnyOfAnyInput(args, function);
+            } else {
+                validateAnyOfAnyInput(bagArgs, function);
+            }
+        }
+    }
+
+    private void validateAnyOfAnyInput(List<Evaluatable> inputs, Function function) {
+
+        for (int i = 0; i < inputs.size(); i++) {
+            for (int j = i + 1; j < inputs.size(); j++) {
+                List<Evaluatable> inputForCheck = new ArrayList();
+                inputForCheck.add(inputs.get(i));
+                inputForCheck.add(inputs.get(j));
+                function.checkInputsNoBag(inputForCheck);
+            }
+        }
+    }
+
+    @Override
+    public void checkInputsNoBag(List inputs) throws IllegalArgumentException {
+
+        // This always throws an exception, since this function by definition must work on bags.
+        throw new IllegalArgumentException("higher-order functions require use of bags");
+    }
+
+    @Override
+    public EvaluationResult evaluate(List inputs, EvaluationCtx context) {
+
+        Iterator iterator = inputs.iterator();
+
+        // Get the first arg, which is the function.
+        Expression xpr = (Expression) (iterator.next());
+        Function function = null;
+
+        if (xpr instanceof Function) {
+            function = (Function) xpr;
+        }
+
+        // Separate the remaining inputs into primitive data types or bags of primitive types.
+        List<AttributeValue> args = new ArrayList<>();
+        List<BagAttribute> bagArgs = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            Evaluatable eval = (Evaluatable) (iterator.next());
+            EvaluationResult result = eval.evaluate(context);
+            if (result.indeterminate()) {
+                return result;
+            }
+            if (result.getAttributeValue().returnsBag()) {
+                bagArgs.add((BagAttribute) (result.getAttributeValue()));
+            } else {
+                args.add((AttributeValue) (result.getAttributeValue()));
+            }
+        }
+
+        switch (functionId) {
+            case ID_ANY_OF:
+                return anyAndAllHelper(context, function, args, bagArgs.get(0), false);
+
+            case ID_ALL_OF:
+                return anyAndAllHelper(context, function, args, bagArgs.get(0), true);
+
+            case ID_ANY_OF_ANY:
+                return anyOfAny(context, function, args, bagArgs);
+        }
+        return null;
+    }
+
+    private EvaluationResult anyAndAllHelper(EvaluationCtx context, Function function, List<AttributeValue> values,
+                                             BagAttribute bag, boolean isAllFunction) {
+
+        Iterator it = bag.iterator();
+        while (it.hasNext()) {
+            AttributeValue bagValue = (AttributeValue) (it.next());
+            for (AttributeValue value : values) {
+                EvaluationResult result = getEvaluationResult(context, function, value, bagValue, isAllFunction);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return new EvaluationResult(BooleanAttribute.getInstance(isAllFunction));
+    }
+
+    private EvaluationResult anyOfAny(EvaluationCtx context, Function function, List<AttributeValue> args,
+                                      List<BagAttribute> bagArgs) {
+
+        // The expression SHALL be evaluated as if the function named in the <Function> argument was applied
+        // between every tuple of the cross product on all bags and the primitive values, and the results were
+        // combined using “urn:oasis:names:tc:xacml:1.0:function:or”
+
+        EvaluationResult result = new EvaluationResult(BooleanAttribute.getInstance(false));
+        if (args.size() > 0) {
+            for (int i = 0; i < args.size() - 1; i++) {
+                AttributeValue value = args.get(i);
+                List<AttributeValue> bagValue = new ArrayList<>();
+                bagValue.add(value);
+                BagAttribute bagArg = new BagAttribute(value.getType(), bagValue);
+                result = anyAndAllHelper(context, function, args.subList(i + 1, args.size()), bagArg, false);
+                if (result.indeterminate() || ((BooleanAttribute) (result.getAttributeValue())).getValue()) {
+                    return result;
+                }
+            }
+            return new EvaluationResult(BooleanAttribute.getInstance(false));
+        }
+        if (bagArgs.size() > 0) {
+            for (int i = 0; i < bagArgs.size(); i++) {
+                for (int j = i + 1; j < bagArgs.size(); j++) {
+                    Iterator iIterator = bagArgs.get(i).iterator();
+                    while (iIterator.hasNext()) {
+                        AttributeValue iValue = (AttributeValue) (iIterator.next());
+                        Iterator jIterator = bagArgs.get(j).iterator();
+                        while (jIterator.hasNext()) {
+                            AttributeValue jValue = (AttributeValue) (jIterator.next());
+                            result = getEvaluationResult(context, function, jValue, iValue, false);
+                            if (result != null && (result.indeterminate() ||
+                                    ((BooleanAttribute) (result.getAttributeValue())).getValue())) {
+                                return result;
+                            }
+                        }
+                    }
+                }
+            }
+            return new EvaluationResult(BooleanAttribute.getInstance(false));
+        }
+        return null;
+    }
+
+    private EvaluationResult getEvaluationResult(EvaluationCtx context, Function function, AttributeValue val1,
+                                                 AttributeValue val2, boolean isAllFunction) {
+
+        List<Evaluatable> params = new ArrayList<>();
+        params.add(val1);
+        params.add(val2);
+        EvaluationResult result = function.evaluate(params, context);
+
+        if (result.indeterminate()) {
+            return result;
+        }
+
+        BooleanAttribute bool = (BooleanAttribute) (result.getAttributeValue());
+        if (bool.getValue() != isAllFunction) {
+            return result;
+        }
+        return null;
+    }
+
+    @Override
+    public URI getIdentifier() {
+
+        return identifier;
+    }
+
+    @Override
+    public URI getType() {
+
+        return getReturnType();
+    }
+
+    @Override
+    public URI getReturnType() {
+
+        if (earlyException != null) {
+            throw earlyException;
+        }
+        return returnTypeURI;
+    }
+
+    @Override
+    public boolean returnsBag() {
+
+        return false;
+    }
+
+    @Override
+    public String encode() {
+
+        StringBuilder builder = new StringBuilder();
+        encode(builder);
+        return builder.toString();
+    }
+
+    @Override
+    public void encode(StringBuilder builder) {
+
+        builder.append("<Function FunctionId=\"").append(getIdentifier().toString()).append("\"/>\n");
+    }
+}

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 
 package org.wso2.balana.cond.xacml3;

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
@@ -69,7 +69,7 @@ public class XACML3HigherOrderFunction implements Function {
     static {
         try {
             returnTypeURI = new URI(BooleanAttribute.identifier);
-        } catch (Exception e) {
+        } catch (URISyntaxException e) {
             earlyException = new IllegalArgumentException();
             earlyException.initCause(e);
         }

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
@@ -26,7 +26,6 @@ import org.wso2.balana.cond.EvaluationResult;
 import org.wso2.balana.cond.Expression;
 import org.wso2.balana.cond.Function;
 import org.wso2.balana.cond.FunctionBase;
-import org.wso2.balana.cond.VariableReference;
 import org.wso2.balana.ctx.EvaluationCtx;
 
 import java.net.URI;
@@ -59,7 +58,7 @@ public class XACML3HigherOrderFunction implements Function {
     private static final int ID_ANY_OF_ANY = 2;
 
     // Internal mapping of names to ids.
-    private final static Map<String, Integer> idMap;
+    private final static Map<String, Integer> ID_MAP;
 
     private int functionId;
     private URI identifier;
@@ -78,7 +77,7 @@ public class XACML3HigherOrderFunction implements Function {
         nameIdMap.put(NAME_ANY_OF, Integer.valueOf(ID_ANY_OF));
         nameIdMap.put(NAME_ALL_OF, Integer.valueOf(ID_ALL_OF));
         nameIdMap.put(NAME_ANY_OF_ANY, Integer.valueOf(ID_ANY_OF_ANY));
-        idMap = Collections.unmodifiableMap(nameIdMap);
+        ID_MAP = Collections.unmodifiableMap(nameIdMap);
     }
 
     /**
@@ -90,7 +89,7 @@ public class XACML3HigherOrderFunction implements Function {
     public XACML3HigherOrderFunction(String functionName) {
 
         // Try to get the function's identifier.
-        Integer i = (Integer) (idMap.get(functionName));
+        Integer i = (Integer) (ID_MAP.get(functionName));
         if (i == null) {
             throw new IllegalArgumentException("Unknown function: " + functionName);
         }
@@ -111,7 +110,7 @@ public class XACML3HigherOrderFunction implements Function {
      */
     public static Set getSupportedIdentifiers() {
 
-        return Collections.unmodifiableSet(idMap.keySet());
+        return Collections.unmodifiableSet(ID_MAP.keySet());
     }
 
     @Override
@@ -173,7 +172,7 @@ public class XACML3HigherOrderFunction implements Function {
             }
             // The expression SHALL be evaluated as if the function named in the <Function> argument was applied
             // between every tuple of the cross product on all bags and the primitive values.
-            if (args.size() > 0) {
+            if (!args.isEmpty()) {
                 validateAnyOfAnyInput(args, function);
             } else {
                 validateAnyOfAnyInput(bagArgs, function);
@@ -267,7 +266,7 @@ public class XACML3HigherOrderFunction implements Function {
         // combined using “urn:oasis:names:tc:xacml:1.0:function:or”
 
         EvaluationResult result = new EvaluationResult(BooleanAttribute.getInstance(false));
-        if (args.size() > 0) {
+        if (!args.isEmpty()) {
             for (int i = 0; i < args.size() - 1; i++) {
                 AttributeValue value = args.get(i);
                 List<AttributeValue> bagValue = new ArrayList<>();
@@ -280,7 +279,7 @@ public class XACML3HigherOrderFunction implements Function {
             }
             return new EvaluationResult(BooleanAttribute.getInstance(false));
         }
-        if (bagArgs.size() > 0) {
+        if (!bagArgs.isEmpty()) {
             for (int i = 0; i < bagArgs.size(); i++) {
                 for (int j = i + 1; j < bagArgs.size(); j++) {
                     Iterator iIterator = bagArgs.get(i).iterator();

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
@@ -74,9 +74,9 @@ public class XACML3HigherOrderFunction implements Function {
         }
 
         Map<String, Integer> nameIdMap = new HashMap<>();
-        nameIdMap.put(NAME_ANY_OF, Integer.valueOf(ID_ANY_OF));
-        nameIdMap.put(NAME_ALL_OF, Integer.valueOf(ID_ALL_OF));
-        nameIdMap.put(NAME_ANY_OF_ANY, Integer.valueOf(ID_ANY_OF_ANY));
+        nameIdMap.put(NAME_ANY_OF, ID_ANY_OF);
+        nameIdMap.put(NAME_ALL_OF, ID_ALL_OF);
+        nameIdMap.put(NAME_ANY_OF_ANY, ID_ANY_OF_ANY);
         ID_MAP = Collections.unmodifiableMap(nameIdMap);
     }
 
@@ -89,11 +89,11 @@ public class XACML3HigherOrderFunction implements Function {
     public XACML3HigherOrderFunction(String functionName) {
 
         // Try to get the function's identifier.
-        Integer i = (Integer) (ID_MAP.get(functionName));
+        Integer i = ID_MAP.get(functionName);
         if (i == null) {
             throw new IllegalArgumentException("Unknown function: " + functionName);
         }
-        functionId = i.intValue();
+        functionId = i;
 
         // Setup the URI form of this function's identity.
         try {
@@ -124,7 +124,7 @@ public class XACML3HigherOrderFunction implements Function {
         }
 
         // Try to cast the first element into a function.
-        Function function = null;
+        Function function;
 
         if (list[0] instanceof Function) {
             function = (Function) (list[0]);
@@ -225,7 +225,7 @@ public class XACML3HigherOrderFunction implements Function {
             if (result.getAttributeValue().returnsBag()) {
                 bagArgs.add((BagAttribute) (result.getAttributeValue()));
             } else {
-                args.add((AttributeValue) (result.getAttributeValue()));
+                args.add(result.getAttributeValue());
             }
         }
 

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/XACML3HigherOrderFunction.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -58,7 +59,7 @@ public class XACML3HigherOrderFunction implements Function {
     private static final int ID_ANY_OF_ANY = 2;
 
     // Internal mapping of names to ids.
-    private static HashMap<String, Integer> idMap;
+    private final static Map<String, Integer> idMap;
 
     private int functionId;
     private URI identifier;
@@ -70,15 +71,14 @@ public class XACML3HigherOrderFunction implements Function {
         try {
             returnTypeURI = new URI(BooleanAttribute.identifier);
         } catch (URISyntaxException e) {
-            earlyException = new IllegalArgumentException();
-            earlyException.initCause(e);
+            earlyException = new IllegalArgumentException(e);
         }
 
-        idMap = new HashMap<String, Integer>();
-
-        idMap.put(NAME_ANY_OF, Integer.valueOf(ID_ANY_OF));
-        idMap.put(NAME_ALL_OF, Integer.valueOf(ID_ALL_OF));
-        idMap.put(NAME_ANY_OF_ANY, Integer.valueOf(ID_ANY_OF_ANY));
+        Map<String, Integer> nameIdMap = new HashMap<>();
+        nameIdMap.put(NAME_ANY_OF, Integer.valueOf(ID_ANY_OF));
+        nameIdMap.put(NAME_ALL_OF, Integer.valueOf(ID_ALL_OF));
+        nameIdMap.put(NAME_ANY_OF_ANY, Integer.valueOf(ID_ANY_OF_ANY));
+        idMap = Collections.unmodifiableMap(nameIdMap);
     }
 
     /**
@@ -99,8 +99,8 @@ public class XACML3HigherOrderFunction implements Function {
         // Setup the URI form of this function's identity.
         try {
             identifier = new URI(functionName);
-        } catch (URISyntaxException use) {
-            throw new IllegalArgumentException("Invalid URI");
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid URI", e);
         }
     }
 
@@ -120,8 +120,9 @@ public class XACML3HigherOrderFunction implements Function {
         Object[] list = inputs.toArray();
 
         // First, check that we got the right number of parameters.
-        if (list.length < 2)
+        if (list.length < 2) {
             throw new IllegalArgumentException("requires more than two inputs");
+        }
 
         // Try to cast the first element into a function.
         Function function = null;
@@ -166,7 +167,7 @@ public class XACML3HigherOrderFunction implements Function {
             }
         } else {
             // The remaining arguments are either primitive data types or bags of primitive types.
-            if (args.size() > 0 && bagArgs.size() > 0) {
+            if (!args.isEmpty() && !bagArgs.isEmpty()) {
                 throw new IllegalArgumentException("The arguments can be are either primitive data types or " +
                         "bags of primitive types. " + getIdentifier());
             }

--- a/modules/balana-core/src/test/java/org/wso2/balana/BaseTestCase.java
+++ b/modules/balana-core/src/test/java/org/wso2/balana/BaseTestCase.java
@@ -20,6 +20,7 @@ package org.wso2.balana;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.wso2.balana.advance.AdvanceTestV3;
+import org.wso2.balana.advance.XACML3HigherOrderFunctionTest;
 import org.wso2.balana.basic.TestFunctionV3;
 import org.wso2.balana.basic.BasicTestV3;
 import org.wso2.balana.basic.TestMultipleRequestV3;
@@ -51,6 +52,9 @@ public class BaseTestCase extends TestSuite {
         testSuite.addTestSuite(ConformanceTestV3.class);
         // test that has been written for jira issue
         testSuite.addTestSuite(AdvanceTestV3.class);
+
+        // Test case for XACML3 Higher Order Functions. (any-of, all-of and any-of-any)
+        testSuite.addTestSuite(XACML3HigherOrderFunctionTest.class);
         return testSuite;
     }
 }

--- a/modules/balana-core/src/test/java/org/wso2/balana/advance/XACML3HigherOrderFunctionTest.java
+++ b/modules/balana-core/src/test/java/org/wso2/balana/advance/XACML3HigherOrderFunctionTest.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 
 package org.wso2.balana.advance;

--- a/modules/balana-core/src/test/java/org/wso2/balana/advance/XACML3HigherOrderFunctionTest.java
+++ b/modules/balana-core/src/test/java/org/wso2/balana/advance/XACML3HigherOrderFunctionTest.java
@@ -27,6 +27,7 @@ import org.wso2.balana.attr.StringAttribute;
 import org.wso2.balana.cond.Apply;
 import org.wso2.balana.cond.EqualFunction;
 import org.wso2.balana.cond.EvaluationResult;
+import org.wso2.balana.cond.Expression;
 import org.wso2.balana.cond.GeneralBagFunction;
 import org.wso2.balana.cond.xacml3.XACML3HigherOrderFunction;
 
@@ -44,14 +45,12 @@ import static org.wso2.balana.utils.Constants.PolicyConstants.XACMLData.FUNCTION
  */
 public class XACML3HigherOrderFunctionTest extends TestCase {
 
-    private static Log log = LogFactory.getLog(XACML3HigherOrderFunctionTest.class);
-
     public void testCheckInputs() {
 
         XACML3HigherOrderFunction anyOfFunction = new XACML3HigherOrderFunction(NAME_ANY_OF);
         XACML3HigherOrderFunction allOfFunction = new XACML3HigherOrderFunction(NAME_ALL_OF);
 
-        List inputs = new ArrayList();
+        List<Expression> inputs = new ArrayList();
         inputs.add(new EqualFunction(NAME_STRING_EQUAL));
         inputs.add(new StringAttribute("Paul"));
         inputs.add(new StringAttribute("John"));
@@ -117,7 +116,7 @@ public class XACML3HigherOrderFunctionTest extends TestCase {
         XACML3HigherOrderFunction anyOfFunction = new XACML3HigherOrderFunction(NAME_ANY_OF);
         XACML3HigherOrderFunction allOfFunction = new XACML3HigherOrderFunction(NAME_ALL_OF);
 
-        List inputs = new ArrayList();
+        List<Expression> inputs = new ArrayList();
         inputs.add(new EqualFunction(NAME_STRING_EQUAL));
         inputs.add(new StringAttribute("Paul"));
         inputs.add(new StringAttribute("John"));

--- a/modules/balana-core/src/test/java/org/wso2/balana/advance/XACML3HigherOrderFunctionTest.java
+++ b/modules/balana-core/src/test/java/org/wso2/balana/advance/XACML3HigherOrderFunctionTest.java
@@ -1,0 +1,223 @@
+/*
+ *  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.balana.advance;
+
+import junit.framework.TestCase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assert;
+import org.wso2.balana.attr.BooleanAttribute;
+import org.wso2.balana.attr.StringAttribute;
+import org.wso2.balana.cond.Apply;
+import org.wso2.balana.cond.EqualFunction;
+import org.wso2.balana.cond.EvaluationResult;
+import org.wso2.balana.cond.GeneralBagFunction;
+import org.wso2.balana.cond.xacml3.XACML3HigherOrderFunction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.wso2.balana.cond.EqualFunction.NAME_STRING_EQUAL;
+import static org.wso2.balana.cond.xacml3.XACML3HigherOrderFunction.NAME_ALL_OF;
+import static org.wso2.balana.cond.xacml3.XACML3HigherOrderFunction.NAME_ANY_OF;
+import static org.wso2.balana.cond.xacml3.XACML3HigherOrderFunction.NAME_ANY_OF_ANY;
+import static org.wso2.balana.utils.Constants.PolicyConstants.XACMLData.FUNCTION_BAG;
+
+/**
+ * Test case for XACML3 Higher Order Functions. (any-of, all-of and any-of-any)
+ */
+public class XACML3HigherOrderFunctionTest extends TestCase {
+
+    private static Log log = LogFactory.getLog(XACML3HigherOrderFunctionTest.class);
+
+    public void testCheckInputs() {
+
+        XACML3HigherOrderFunction anyOfFunction = new XACML3HigherOrderFunction(NAME_ANY_OF);
+        XACML3HigherOrderFunction allOfFunction = new XACML3HigherOrderFunction(NAME_ALL_OF);
+
+        List inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+
+        try {
+            anyOfFunction.checkInputs(inputs);
+            allOfFunction.checkInputs(inputs);
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+        try {
+            allOfFunction.checkInputs(inputs);
+            Assert.fail("Input validation failed for all of");
+            anyOfFunction.checkInputs(inputs);
+            Assert.fail("Input validation failed for any of");
+        } catch (IllegalArgumentException err) {
+            // Expected error.
+        }
+
+        // Test for any-of-any
+        XACML3HigherOrderFunction anyOfAnyFunction = new XACML3HigherOrderFunction(NAME_ANY_OF_ANY);
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(new StringAttribute("Ringo"));
+
+        try {
+            anyOfAnyFunction.checkInputs(inputs);
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+
+        try {
+            anyOfAnyFunction.checkInputs(inputs);
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+
+        try {
+            anyOfAnyFunction.checkInputs(inputs);
+            Assert.fail("Input validation failed for any of any");
+        } catch (IllegalArgumentException err) {
+            // Expected error.
+        }
+    }
+
+    public void testEvaluate() {
+
+        XACML3HigherOrderFunction anyOfFunction = new XACML3HigherOrderFunction(NAME_ANY_OF);
+        XACML3HigherOrderFunction allOfFunction = new XACML3HigherOrderFunction(NAME_ALL_OF);
+
+        List inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+
+        try {
+            EvaluationResult evaluate = anyOfFunction.evaluate(inputs, null);
+            Assert.assertTrue(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        try {
+            EvaluationResult evaluate = allOfFunction.evaluate(inputs, null);
+            Assert.assertFalse(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Alex"));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+
+        try {
+            EvaluationResult evaluate = anyOfFunction.evaluate(inputs, null);
+            Assert.assertFalse(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(getApply(new String[]{"Paul", "Paul", "Paul"}));
+        try {
+            EvaluationResult evaluate = allOfFunction.evaluate(inputs, null);
+            Assert.assertTrue(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        // Test for any-of-any
+        XACML3HigherOrderFunction anyOfAnyFunction = new XACML3HigherOrderFunction(NAME_ANY_OF_ANY);
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(getApply(new String[]{"Paul1", "George1", "Ringo"}));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+        try {
+            EvaluationResult evaluate = anyOfAnyFunction.evaluate(inputs, null);
+            Assert.assertTrue(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(getApply(new String[]{"Paul1", "George1", "Ringo1"}));
+        inputs.add(getApply(new String[]{"Paul", "George", "Ringo"}));
+        try {
+            EvaluationResult evaluate = anyOfAnyFunction.evaluate(inputs, null);
+            Assert.assertFalse(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(new StringAttribute("Ringo"));
+        try {
+            EvaluationResult evaluate = anyOfAnyFunction.evaluate(inputs, null);
+            Assert.assertFalse(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+
+        inputs = new ArrayList();
+        inputs.add(new EqualFunction(NAME_STRING_EQUAL));
+        inputs.add(new StringAttribute("Paul"));
+        inputs.add(new StringAttribute("John"));
+        inputs.add(new StringAttribute("Paul"));
+        try {
+            EvaluationResult evaluate = anyOfAnyFunction.evaluate(inputs, null);
+            Assert.assertTrue(((BooleanAttribute) evaluate.getAttributeValue()).getValue());
+        } catch (IllegalArgumentException err) {
+            Assert.fail("Input validation failed");
+        }
+    }
+
+    private Apply getApply(String[] values) {
+
+        List<StringAttribute> applyList = new ArrayList();
+        for (String value : values) {
+            applyList.add(new StringAttribute(value));
+        }
+        return new Apply(new GeneralBagFunction(FUNCTION_BAG), applyList);
+    }
+}


### PR DESCRIPTION
Fix https://github.com/wso2/product-is/issues/6501

**urn:oasis:names:tc:xacml:3.0:function:any-of**

This function applies a Boolean function between specific primitive values and a bag of values, and SHALL return "True" if and only if the predicate is "True" for at least one element of the bag.

This function SHALL take n+1 arguments, where n is one or greater. The first argument SHALL be an <Function> element that names a Boolean function that takes n arguments of primitive types.  Under the remaining n arguments, n-1 parameters SHALL be values of primitive data-types and one SHALL be a bag of a primitive data-type.  The expression SHALL be evaluated as if the function named in the <Function> argument were applied to the n-1 non-bag arguments and each element of the bag argument and the results are combined with “urn:oasis:names:tc:xacml:1.0:function:or”.

**urn:oasis:names:tc:xacml:3.0:function:all-of**

This function applies a Boolean function between a specific primitive value and a bag of values, and returns "True" if and only if the predicate is "True" for every element of the bag.

This function SHALL take n+1 arguments, where n is one or greater.  The first argument SHALL be a <Function> element that names a Boolean function that takes n arguments of primitive types. Under the remaining n arguments, n-1 parameters SHALL be values of primitive data-types and one SHALL be a bag of a primitive data-type. The expression SHALL be evaluated as if the function named in the <Function> argument were applied to the n-1 non-bag arguments and each element of the bag argument and the results are combined with “urn:oasis:names:tc:xacml:1.0:function:and”.


**urn:oasis:names:tc:xacml:3.0:function:any-of-any**

This function applies a Boolean function on each tuple from the cross product on all bags arguments, and returns "True" if and only if the predicate is "True" for at least one inside-function call.

This function SHALL take n+1 arguments, where n is one or greater.  The first argument SHALL be an <Function> element that names a Boolean function that takes n arguments. The remaining arguments are either primitive data types or bags of primitive types.  The expression SHALL be evaluated as if the function named in the <Function> argument was applied between every tuple of the cross product on all bags and the primitive values, and the results were combined using “urn:oasis:names:tc:xacml:1.0:function:or”.  The semantics are that the result of the expression SHALL be "True" if and only if the applied predicate is "True" for at least one function call on the tuples from the bags and primitive values.



[1] - http://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-os-en.html#_Toc325047251