### PR TITLE
Removed override of returnsBag in GeneralBagFunction.

### DIFF
--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/GeneralBagFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/GeneralBagFunction.java
@@ -278,13 +278,7 @@ public class GeneralBagFunction extends BagFunction {
         return new EvaluationResult(attrResult);
     }
 
-    @Override
-    public final boolean returnsBag() {
-
-        return getReturnsBag(getFunctionName());
-    }
-
-    /**
+     /**
      * Private class that is used for mapping each function to it set of parameters.
      */
     private static class BagParameters {


### PR DESCRIPTION
## Purpose
Resolves issue https://github.com/wso2/balana/issues/144

I removed the override of the returnsBag function so that the code uses the field from the base class. I didn't find any issues with this in Balana tests nor in tests for my project using it.